### PR TITLE
Replace non-standard malloc.h with stdlib.h in tools

### DIFF
--- a/src/tools/16to8/16to8.c
+++ b/src/tools/16to8/16to8.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>
 
 unsigned char *table;

--- a/src/tools/colormap/colormap.c
+++ b/src/tools/colormap/colormap.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>
 
 unsigned char *cmap, *pal;

--- a/src/tools/pcx2pal/pcx2pal.c
+++ b/src/tools/pcx2pal/pcx2pal.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>
 
 int main(int argc, char *argv[])

--- a/src/tools/pcx2wal/pcx2wal.c
+++ b/src/tools/pcx2wal/pcx2wal.c
@@ -14,7 +14,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>
 
 #define FLIST_LEN 2000 /* max of textures to be converted at once */


### PR DESCRIPTION
Some tools (`16to8`, `colormap`, `pcx2pal`, `pcx2wal`) have `#include <malloc.h>`. This is non-standard header specific to GNU libc or even GNU libc only on Linux. Replaced with standard `malloc.h`.

MacOS (at least 10.13.6) does not have `malloc.h`.

Looks like these tools don't use nonstandard functions from this file (such as `mallinfo`) so include can be safely replaced.

Basic testing of these utils: https://gist.github.com/kolen/f383572d99fcdf91edc027269a6ac003