### PR TITLE
Replace Sys_Error with Com_Error where it has additional arg before format string

### DIFF
--- a/src/client/renderer/sw_draw.c
+++ b/src/client/renderer/sw_draw.c
@@ -146,7 +146,7 @@ void RE_Draw_StretchPicImplementation(int x, int y, int w, int h, image_t *pic)
   int skip;
 
   if ((x < 0) || (x + w > vid.width) || (y + h > vid.height)) {
-    Sys_Error(ERR_FATAL, "Draw_Pic: bad coordinates");
+    Com_Error(ERR_FATAL, "Draw_Pic: bad coordinates");
   }
 
   height = h;

--- a/src/client/renderer/sw_main.c
+++ b/src/client/renderer/sw_main.c
@@ -915,7 +915,7 @@ void RE_RenderFrame(refdef_t *fd)
   r_newrefdef = *fd;
 
   if (!r_worldmodel && !(r_newrefdef.rdflags & RDF_NOWORLDMODEL))
-    Sys_Error(ERR_FATAL, "R_RenderView: NULL worldmodel");
+    Com_Error(ERR_FATAL, "R_RenderView: NULL worldmodel");
 
   VectorCopy(fd->vieworg, r_refdef.vieworg);
   VectorCopy(fd->viewangles, r_refdef.viewangles);
@@ -1062,7 +1062,7 @@ void RE_BeginFrame(float camera_separation)
                             "unavailable in this mode\n");
         sw_state.prev_mode = r_mode->value;
       } else {
-        Sys_Error(ERR_FATAL, "ref_soft::RE_BeginFrame() - catastrophic mode change failure\n");
+        Com_Error(ERR_FATAL, "ref_soft::RE_BeginFrame() - catastrophic mode change failure\n");
       }
     }
   }
@@ -1241,7 +1241,7 @@ void Draw_GetPalette(void)
   // get the palette and colormap
   LoadPCX("pics/colormap.pcx", &vid_colormap, &pal, NULL, NULL);
   if (!vid_colormap)
-    Sys_Error(ERR_FATAL, "Couldn't load pics/colormap.pcx");
+    Com_Error(ERR_FATAL, "Couldn't load pics/colormap.pcx");
   vid_alphamap = vid_colormap + 64 * 256;
 
   out = (byte *) d_8to24table;

--- a/src/client/renderer/sw_surf.c
+++ b/src/client/renderer/sw_surf.c
@@ -410,16 +410,16 @@ surfcache_t *D_SCAlloc(int width, int size)
   qboolean wrapped_this_time;
 
   if ((width < 0) || (width > 256))
-    Sys_Error(ERR_FATAL, "D_SCAlloc: bad cache width %d\n", width);
+    Com_Error(ERR_FATAL, "D_SCAlloc: bad cache width %d\n", width);
 
   if ((size <= 0) || (size > 0x10000))
-    Sys_Error(ERR_FATAL, "D_SCAlloc: bad cache size %d\n", size);
+    Com_Error(ERR_FATAL, "D_SCAlloc: bad cache size %d\n", size);
 
   // Add header size
   size += ((char *) sc_base->data - (char *) sc_base);
   size = (size + 3) & ~3;
   if (size > sc_size)
-    Sys_Error(ERR_FATAL, "D_SCAlloc: %i > cache size of %i", size, sc_size);
+    Com_Error(ERR_FATAL, "D_SCAlloc: %i > cache size of %i", size, sc_size);
 
   // if there is not size bytes after the rover, reset to the start
   wrapped_this_time = false;
@@ -440,7 +440,7 @@ surfcache_t *D_SCAlloc(int width, int size)
     // free another
     sc_rover = sc_rover->next;
     if (!sc_rover)
-      Sys_Error(ERR_FATAL, "D_SCAlloc: hit the end of memory");
+      Com_Error(ERR_FATAL, "D_SCAlloc: hit the end of memory");
     if (sc_rover->owner)
       *sc_rover->owner = NULL;
 


### PR DESCRIPTION
`Sys_Error` sometimes called with additional arg before format string (actual function does not have one), causing segfault.

https://github.com/klaussilveira/qengine/blob/619131df9c43b3f1b9f6e06eb96f1fe2dad02936/src/client/renderer/sw_main.c#L1244

https://github.com/klaussilveira/qengine/blob/510c0e8269b2c70896ae0bfbad7fd0d3e0c5b6f8/src/platform/unix/system.c#L253

`Com_Error` has this argument:

https://github.com/klaussilveira/qengine/blob/510c0e8269b2c70896ae0bfbad7fd0d3e0c5b6f8/src/common/clientserver.c#L198

Probably fixes #7. I don't know if this replacement is right. At least it builds and now it quits with fatal error correctly:

```
% ./client

qengine v0.1.0
==============

Byte ordering: little endian

Using '/Users/kolen/items/qengine/build/.//assets' for writing.
couldn't exec default.cfg
couldn't exec config.cfg
couldn't exec autoexec.cfg
Console initialized.
Sound init
Starting SDL audio callback.
SDL audio driver is "coreaudio".
SDL audio initialized.
Sound sampling rate: 44100
==== ShutdownGame ====
Closing SDL audio device...
SDL audio device shut down.
Cmd_RemoveCommand: force_centerview not added
Cmd_RemoveCommand: +mlook not added
Cmd_RemoveCommand: -mlook not added
Shutting down input.
recursive shutdown
Error: Couldn't load pics/colormap.pcx
```