### PR TITLE
Fix build on musl systems and modern CMake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...4.1.2)
 project(qengine VERSION 0.1.0)
 
 option(BUILD_TOOLS "Build tools" ON)
 option(BUILD_SDL "Build SDL platform" ON)
+option(VENDOR_SDL "Vendor SDL library" ON)
 option(BUILD_DOCS "Build documentation" OFF)
 
 add_definitions(-DENGINE_VERSION="${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
@@ -17,12 +18,11 @@ set(SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/src)
 set(PROJECT_INCLUDE_DIRS)
 set(PROJECT_LINK_DIRS)
 set(COMMON_LINKER_FLAGS)
-set(CLIENT_LINKER_FLAGS)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-  list(APPEND COMMON_LINKER_FLAGS "-lm -static-libgcc")
+  list(APPEND COMMON_LINKER_FLAGS -lm -static-libgcc)
 else()
-  list(APPEND COMMON_LINKER_FLAGS "-lm -rdynamic")
+  list(APPEND COMMON_LINKER_FLAGS -lm -rdynamic)
 endif()
 
 # If we're building with gcc for i386 let's define -ffloat-store. This helps the old and crappy x87 FPU to produce
@@ -85,10 +85,11 @@ endif()
 
 # Dependencies
 if(BUILD_SDL)
-  add_subdirectory(vendor/SDL2-2.0.22)
-
-  list(APPEND PROJECT_INCLUDE_DIRS vendor/SDL2-2.0.22/include)
-  list(APPEND COMMON_LINKER_FLAGS SDL2)
+  if(VENDOR_SDL)
+    add_subdirectory(vendor/SDL2-2.0.22 EXCLUDE_FROM_ALL)
+  else()
+    find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2)
+  endif()
 
   set(CLIENT_PLATFORM_SOURCE ${CLIENT_PLATFORM_SOURCE} ${SDL_SOURCE})
 endif()
@@ -264,7 +265,10 @@ add_executable(client
                ${GAME_SOURCE}
                ${GAME_HEADER})
 set_target_properties(client PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-target_link_libraries(client ${COMMON_LINKER_FLAGS} ${CLIENT_LINKER_FLAGS})
+target_link_options(client PRIVATE ${COMMON_LINKER_FLAGS})
+if(BUILD_SDL)
+  target_link_libraries(client PRIVATE SDL2::SDL2)
+endif()
 
 # Dedicated Server
 add_executable(server
@@ -279,7 +283,7 @@ set_target_properties(server
                                  "DEDICATED_ONLY"
                                  RUNTIME_OUTPUT_DIRECTORY
                                  ${CMAKE_BINARY_DIR})
-target_link_libraries(server ${COMMON_LINKER_FLAGS})
+target_link_options(server PRIVATE ${COMMON_LINKER_FLAGS})
 
 if(BUILD_TOOLS)
   add_subdirectory(src/tools)

--- a/src/platform/unix/signalhandler.c
+++ b/src/platform/unix/signalhandler.c
@@ -20,7 +20,7 @@
 
 #include <signal.h>
 
-#ifdef __linux__
+#ifdef __GLIBC__
 
 #include <execinfo.h>
 
@@ -28,7 +28,7 @@
 
 #include "../../common/header/common.h"
 
-#ifdef __linux__
+#ifdef __GLIBC__
 
 void printBacktrace(int sig)
 {

--- a/src/platform/unix/system.c
+++ b/src/platform/unix/system.c
@@ -30,6 +30,7 @@
 #include <fcntl.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <sys/select.h>
 #include <sys/stat.h>
 #include <string.h>
 #include <dirent.h>

--- a/src/tools/16to8/CMakeLists.txt
+++ b/src/tools/16to8/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...4.1.2)
 project(16to8)
 
 set(PROJECT_SOURCES 16to8.c)

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...4.1.2)
 project(tools)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/tools)

--- a/src/tools/bspinfo/CMakeLists.txt
+++ b/src/tools/bspinfo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...4.1.2)
 project(bspinfo)
 
 set(PROJECT_SOURCES bspinfo.c)

--- a/src/tools/colormap/CMakeLists.txt
+++ b/src/tools/colormap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...4.1.2)
 project(colormap)
 
 set(PROJECT_SOURCES colormap.c)

--- a/src/tools/pcx2pal/CMakeLists.txt
+++ b/src/tools/pcx2pal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...4.1.2)
 project(pcx2pal)
 
 set(PROJECT_SOURCES pcx2pal.c)

--- a/src/tools/pcx2wal/CMakeLists.txt
+++ b/src/tools/pcx2wal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...4.1.2)
 project(pcx2wal)
 
 set(PROJECT_SOURCES pcx2wal.c)

--- a/src/tools/qbsp3/CMakeLists.txt
+++ b/src/tools/qbsp3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...4.1.2)
 project(qbsp3)
 
 set(PROJECT_SOURCES

--- a/src/tools/qdata/CMakeLists.txt
+++ b/src/tools/qdata/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...4.1.2)
 project(qdata)
 
 set(PROJECT_SOURCES

--- a/src/tools/qrad3/CMakeLists.txt
+++ b/src/tools/qrad3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...4.1.2)
 project(qrad3)
 
 set(PROJECT_SOURCES

--- a/src/tools/qvis3/CMakeLists.txt
+++ b/src/tools/qvis3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...4.1.2)
 project(qvis3)
 
 set(PROJECT_SOURCES


### PR DESCRIPTION
Three different fixes:
- `execinfo` is specific to Glibc, not "linux". Musl-based systems don't have it, unless you add a dependency on `libexecinfo` which not all of them provide.
- CMake now complains if the minimum version is older than 3.5. I made it into a range instead.
- The included SDL2 version is rather old, and on Linux you'd want to build with the system version anyway, so I added an option to not vendor SDL (-DVENDOR_SDL=OFF). It's on by default, should it be off by default? Or maybe off by default only on Linux?